### PR TITLE
Formal changes in `README.md`

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,18 +1,20 @@
 ![](https://github.com/Circadiaware/circadiaware-design/raw/main/logo/circadiaware-text-logo6-font3-test2.png)
 
-# Welcome to the Circadiaware Collective!
+# Welcome to the Circadiaware collective!
 
-We are a group of researchers, software engineers, citizen scientists and patients advocates working together to conceive novel tools for the study, management and treatment of circadian rhythm sleep-wake disorders such as non-24 or DSPD, which are severely disabling and debilitating.
+We are a group of researchers, software engineers, citizen scientists and patient advocates, working together to conceive novel tools for the study, management and treatment of circadian-rhythm sleep-wake disorders such as [non-24](https://en.wikipedia.org/wiki/Non-24-hour_sleep%E2%80%93wake_disorder) or [DSPD](https://en.wikipedia.org/wiki/Delayed_sleep_phase_disorder), which are severely disabling and debilitating.
 
 In the spirit of open science and transparency, all tools are published under an open-source license and will be free forever!
 
-We welcome everybody to join our collective by contributing to an existing project or by submitting a new open-source resource related to the management or treatment of circadian rhythm sleep-wake disorders. If you are interested and you think you can contribute in any way, please join us to shape the future of circadian rhythm sleep science!
+We welcome everybody to join our collective by contributing to an existing project or by submitting a new open-source resource related to the management or treatment of circadian-rhythm sleep-wake disorders. If you are interested and you think you can contribute in any way, please join us to shape the future of circadian-rhythm sleep science!
 
 The goal of the collective is to deduplicate efforts, bring together people who share common goals (such as developing similar apps), to raise awareness about these poorly known disorders, and to provide a centralized resource on the internet to publicize the tools produced by the community.
 
-If you don't know where to start or if you are a user interested in testing some of our tools, have a look at:
-* [Web Actogram](https://github.com/Circadiaware/webactogram), a novel instantaneous mass screening tool for sleep patterns and maybe disorders by using the web browser's history.
-* [VLiDACMel](https://circadiaware.github.io/VLiDACMel-entrainment-therapy-non24/SleepNon24VLiDACMel.html), an unvalidated experimental protocol to manage the non-24 and DSPD circadian rhythm disorders mainly using very long light therapy (and includes a review of circadian rhythm sleep science).
-* [Wearadian](https://circadiaware.github.io/wearadian/docs/Wearadian.html), designs for experiments to 24/7 in-situ monitor circadian rhythm sleep disorders biomarkers, used to collect the data of the [MyNon24Sleep](https://figshare.com/projects/MyNon24_-_A_self-study_of_the_circadian_rhythm_and_its_altering_factors/101804) dataset.
-* Our complete list of projects: https://github.com/Circadiaware/crd-projects and https://github.com/orgs/Circadiaware/repositories
+If you don't know where to start, or if you're interested in testing some of our tools, have a look at:
+* [Web Actogram](https://github.com/Circadiaware/webactogram) &mdash; A novel, instantaneous mass screening tool for sleep patterns&mdash;and maybe disorders&mdash;by using the web browser's history.
+* [VLiDACMel](https://circadiaware.github.io/VLiDACMel-entrainment-therapy-non24/SleepNon24VLiDACMel.html) &mdash; An unvalidated, experimental protocol to manage the non-24 and DSPD circadian-rhythm disorders&mdash;mainly using very long light therapy. (Also includes a review of circadian-rhythm sleep science.)
+* [Wearadian](https://circadiaware.github.io/wearadian/docs/Wearadian.html) &mdash; Designs for experiments to 24/7-in-situ-monitor circadian-rhythm sleep disorder biomarkers. Used to collect the data of the [MyNon24Sleep](https://figshare.com/projects/MyNon24_-_A_self-study_of_the_circadian_rhythm_and_its_altering_factors/101804) dataset.
+* Our complete list of projects:
+  * https://github.com/Circadiaware/crd-projects
+  * https://github.com/orgs/Circadiaware/repositories
 * Check also our most popular projects pinned just below.


### PR DESCRIPTION
- In other places, you don't capitalize "collective" in "Circadiaware collective". I don't think it's part of the proper name, so I uncapitalized it.
- Writing "circadian-rhythm" with a hyphen in composite nouns has to do with "circadian-rhythm" - an adjective-noun pair - first forming a unit, before it's joined with another noun to form a composite noun. This pattern is sometimes put in second place, but you already applied it with "open-source license"; other common examples would be "long-term memory", "solid-state drive", "short-term investment". I'm a fan of applying this pattern rather more than less to avoid inconsistency.
- I used hyphens in "24/7-in-situ-monitor", because it functions as a single verb. If you'd like to avoid the hyphens, you'd have to phrase it with the noun "monitoring" (but this could lead to using the preposition "for" twice).
- I'm not sure whether it should be "A novel instantaneous-mass-screening tool" instead of "A novel, instantaneous mass screening tool". The question is: What is an instantaneous tool? So, "A novel instantaneous-mass-screening tool" may be more reasonable. But I can't say that I understand what the sentence wants to convey.
- You could also decide to write "sleep-wake" with an en dash: "sleep&ndash;wake" (HTML entity `&ndash;` in Markdown). Writing it with a hyphen would be a simplification by using a substitution character (not saying it's an invalid decision for practical purposes). Examples on Wikipedia with en dashes that should make the point clear what's it about:
  - "Non-24-hour sleep–wake disorder": https://en.wikipedia.org/wiki/Non-24-hour_sleep%E2%80%93wake_disorder
  - "delayed sleep–wake phase disorder" (in text): https://en.wikipedia.org/wiki/Delayed_sleep_phase_disorder
  - "key–value store": https://en.wikipedia.org/wiki/Key%E2%80%93value_database
  - "Cost–benefit analysis": https://en.wikipedia.org/wiki/Cost%E2%80%93benefit_analysis
  - "North–South divide": https://en.wikipedia.org/wiki/North%E2%80%93South_divide
- Should "produced by the community" rather be "produced by the collective"? The current phrasing may well be okay, though.
